### PR TITLE
添加命令行工具帮助，指定输入输出目录，递归输入目录文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ npm i super-tinypng -g # or yarn global add super-tinypng
 super-tinypng
 ```
 
+如果想要处理指定输入和输出目录：
+```bash
+super-tinypng  --path /your/path/to --out /your/path/to
+```
+
 ## 说明
 - tinypng 默认是会对用户上传数量有限制的，使用了 `X-Forwarded-For` 头绕过该限制
-- 为了简化，不可以递归遍历文件夹
-- 为了简化，不支持配置，只能压缩当前目录下的图片，并且会在当前目录下创建一个 output 目录，把压缩成功的图片放到里面
+- ~~为了简化，不可以递归遍历文件夹~~
+- ~~为了简化，不支持配置，只能压缩当前目录下的图片，并且会在当前目录下创建一个 output 目录，把压缩成功的图片放到里面~~
 
 ## 免责声明
 

--- a/index.js
+++ b/index.js
@@ -11,14 +11,61 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const { URL } = require('url');
+// 获取命令行参数
+const args = process.argv;
+const helpText=`super-tinypng 图片压缩命令行工具 - 处理输入目录中的图片并将压缩后的图片保存到指定的输出目录。
+
+用法:
+  super-tinypng [选项]
+
+选项:
+  --path <路径>    指定输入目录的路径。默认值为当前目录。
+  --out <路径>     指定输出目录的路径。默认值为输入目录下的 "output" 目录。
+
+其他选项:
+  --help          显示帮助信息并退出。
+  --version       显示工具版本信息并退出。
+
+示例用法:
+  1. 使用默认参数运行工具:
+     super-tinypng
+
+  2. 指定输入目录并将结果保存在默认的输出目录:
+     super-tinypng --path /path/to/input
+
+  3. 指定输入目录和输出目录的路径:
+     super-tinypng --path /path/to/input --out /path/to/output
+
+注意:
+  - 输入目录中的文件将会被处理，处理结果将保存到输出目录中。
+  - 如果输出目录不存在，工具将尝试创建它。`;
+
+const helpIndex = args.indexOf('--help');
+
+if (helpIndex !== -1) {
+  console.log(helpText);
+  return
+}
+
+if (args.includes("--version")){
+  console.log('1.0.1')
+  return
+}
+
+// 查找 "--path" 参数并获取其值
+const pathIndex = args.indexOf('--path');
+let root = process.cwd();
+
+if (pathIndex !== -1 && pathIndex + 1 < args.length) {
+  root = args[pathIndex + 1];
+  if (!fs.existsSync(root)) {
+    throw new Error( root + " 目录不存在")
+  }
+}
 
 
-const cwd = process.cwd();
-
-const root = cwd;
-  exts = ['.jpg', '.png'],
-  max = 5200000; // 5MB == 5242848.754299136
-
+const exts = ['.jpg', '.png'];
+const max = 5200000; // 5MB == 5242848.754299136
 
 const options = {
   method: 'POST',
@@ -36,7 +83,6 @@ const options = {
 
 fileList(root);
 
-
 // 生成随机IP， 赋值给 X-Forwarded-For
 function getRandomIP() {
   return Array.from(Array(4)).map(() => parseInt(Math.random() * 255)).join('.')
@@ -47,28 +93,23 @@ function fileList(folder) {
   fs.readdir(folder, (err, files) => {
     if (err) console.error(err);
     files.forEach(file => {
-      fileFilter(path.join(folder, file));
+      const filePath = path.join(folder, file);
+      fs.stat(filePath, (err, stats) => {
+        if (err) return console.error(err);
+        if (stats.isDirectory()) {
+          fileList(filePath);
+        } else if (
+          // 必须是文件，小于5MB，后缀 jpg||png
+          stats.size <= max &&
+          stats.isFile() &&
+          exts.includes(path.extname(file))
+        ) {
+          // 通过 X-Forwarded-For 头部伪造客户端IP
+          options.headers['X-Forwarded-For'] = getRandomIP();
+          fileUpload(filePath);
+        }
+      });
     });
-  });
-}
-
-// 过滤文件格式，返回所有jpg,png图片
-function fileFilter(file) {
-  fs.stat(file, (err, stats) => {
-    if (err) return console.error(err);
-    if (
-      // 必须是文件，小于5MB，后缀 jpg||png
-      stats.size <= max &&
-      stats.isFile() &&
-      exts.includes(path.extname(file))
-    ) {
-      
-      // 通过 X-Forwarded-For 头部伪造客户端IP
-      options.headers['X-Forwarded-For'] = getRandomIP();
-
-      fileUpload(file); // console.log('可以压缩：' + file);
-    }
-    // if (stats.isDirectory()) fileList(file + '/');
   });
 }
 
@@ -93,13 +134,21 @@ function fileUpload(img) {
   });
   req.end();
 }
+
 // 该方法被循环调用,请求图片数据
 function fileUpdate(imgpath, obj) {
-  const outputDir = path.join(cwd , 'output');
-  imgpath = path.join(cwd , 'output', imgpath.replace(cwd, ''));
+  const outputPathIndex = args.indexOf('--out');
+  let outputDir =path.join(root, 'output');
 
-  if(!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir);
+  if (outputPathIndex !== -1 && outputPathIndex + 1 < args.length) {
+    outputDir = args[outputPathIndex + 1];
+  }
+  imgpath = path.join(outputDir, imgpath.replace(root, ''));
+  const imgdir = path.dirname(imgpath);
+
+  
+  if (!fs.existsSync(imgdir)) {
+    fs.mkdirSync(imgdir, { recursive: true });
   }
 
   let options = new URL(obj.output.url);
@@ -111,6 +160,7 @@ function fileUpdate(imgpath, obj) {
     });
 
     res.on('end', function() {
+      console.log("imgpath:" + imgpath)
       fs.writeFile(imgpath, body, 'binary', err => {
         if (err) return console.error(err);
         console.log(
@@ -126,3 +176,5 @@ function fileUpdate(imgpath, obj) {
   });
   req.end();
 }
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "super-tinypng",
+  "version": "1.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "super-tinypng",
+      "version": "1.0.1",
+      "license": "ISC",
+      "bin": {
+        "super-tinypng": "index.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
添加命令行工具帮助，指定输入输出目录，递归输入目录文件

super-tinypng 图片压缩命令行工具 - 处理输入目录中的图片并将压缩后的图片保存到指定的输出目录。

用法:
  super-tinypng [选项]

选项:
  --path <路径>    指定输入目录的路径。默认值为当前目录。
  --out <路径>     指定输出目录的路径。默认值为输入目录下的 "output" 目录。

其他选项:
  --help          显示帮助信息并退出。
  --version       显示工具版本信息并退出。

示例用法:
  1. 使用默认参数运行工具:
     super-tinypng

  2. 指定输入目录并将结果保存在默认的输出目录:
     super-tinypng --path /path/to/input

  3. 指定输入目录和输出目录的路径:
     super-tinypng --path /path/to/input --out /path/to/output

注意:
  - 输入目录中的文件将会被处理，处理结果将保存到输出目录中。
  - 如果输出目录不存在，工具将尝试创建它。`